### PR TITLE
Improve copy button visibility on touch devices

### DIFF
--- a/index.html
+++ b/index.html
@@ -83,8 +83,16 @@
         .prompt-card:hover .copy-button {
             opacity: 1;
         }
+        .prompt-card:focus-within .copy-button {
+            opacity: 1;
+        }
         .copy-button:hover {
             background-color: #475569;
+        }
+        @media (hover: none) {
+            .copy-button {
+                opacity: 1;
+            }
         }
     </style>
 </head>


### PR DESCRIPTION
## Summary
- keep AI prompt copy button visible for touch devices
- show copy button when prompt cards are focused

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896dd033c4c83338e2edac8864aa79d